### PR TITLE
Fix quotes used in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ import { PackageSigner } from '@chromeos/android-package-signer';
 async function keyGen(): Promise<string> {
   const packageSigner = new PackageSigner(password, alias);
   const base64Der = await packageSigner.generateKey({
-      commonName: “Alexander Nohe”,
-      organizationName: “Google, Inc”,
-      organizationUnit: “DevRel”,
-      countryCode: “US”,
+      commonName: 'Alexander Nohe',
+      organizationName: 'Google, Inc',
+      organizationUnit: 'DevRel',
+      countryCode: 'US',
     });
 
   // To download the keys.


### PR DESCRIPTION
This changes the quotation mark to non-slated quotes which will help with copying and pasting from the README